### PR TITLE
[IMP] - Picking types without assigned users are show to everyone to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ For Support :
 * Website : www.techspawn.com
 * Facebook : www.facebook.com/techspawnsolutions/ 
 * Twitter : www.twitter.com/techspawn/
+
+Contributors:
+=============
+
+* Fábrica de Software Libre: www.fslibre.com

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -32,13 +32,14 @@
     'website': "http://www.techspawn.com",
 
     'category': 'Warehouse',
-    'version': '10.0.0.1',
+    'version': '10.0.0.2',
 
     'depends': ['base', 'stock'],
 
     'data': [
         'views/users.xml',
-        'security/security.xml', 
+        'views/stock.xml',
+        'security/security.xml',
     ],
     'installable': True,
     'application': False,

--- a/models/stock.py
+++ b/models/stock.py
@@ -20,6 +20,14 @@ class ResUsers(models.Model):
         'user_id', 'picking_type_id', string='Default Warehouse Operations')
 
 
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    allowed_user_ids = fields.Many2many(
+        'res.users', 'stock_picking_type_users_rel',
+        'picking_type_id', 'user_id', string='Allowed users', )
+
+
 class stock_move(models.Model):
     _inherit = 'stock.move'
 

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,2 +1,0 @@
-id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_warehouse_stock_locations_warehouse_stock_locations,warehouse_stock_locations.warehouse_stock_locations,model_warehouse_stock_locations_warehouse_stock_locations,,1,0,0,0

--- a/security/security.xml
+++ b/security/security.xml
@@ -4,6 +4,6 @@
         <field name="name">Filter Stock Picking Type Allowed</field>
         <field name="model_id" search="[('model','=','stock.picking.type')]" model="ir.model"/>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-        <field name="domain_force">[('id','in', [ p.id for p in user.default_picking_type_ids ])]</field>
+        <field name="domain_force">['|', ('allowed_user_ids','=', False), ('id','in', [ p.id for p in user.default_picking_type_ids ])]</field>
     </record>
 </odoo>

--- a/views/stock.xml
+++ b/views/stock.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">Picking type allowed users form view</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="inside">
+                <group string="Allowed users" groups="stock.group_stock_manager">
+                    <field name="allowed_user_ids" widget="many2many_tags"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Fixes error to create new location as the user doesn't have the rights to read the newly created warehouse.
- Adds a "allowed users" field in the picking views in order to make the assignment of users to a picking type easier.